### PR TITLE
Rewrite the color assignment logic; Add in color picking function; Add in screenshot function

### DIFF
--- a/guis/db_gui.py
+++ b/guis/db_gui.py
@@ -521,7 +521,7 @@ class DBWindow(QWidget):
             reject_diaglog = RejectSummaryAndConfirmDialog(self.df_picked,self.locations_db)
             if(reject_diaglog.exec()):
                 self.select_tray()
-        if self.options.currentText() == _:
+        else:
             QMessageBox.warning(self,"Under Construction","Status except REJECTED is under construction")
 
     def change_grade(self):


### PR DESCRIPTION
The color palette for grades is now from dynamic assignment, with
- red reserved for failed chips
- grey reserved for untested chips
See lines 37-63

The buttons in legends can now be clicked to pick color from color palette
<img width="1500" height="915" alt="Screenshot 2025-10-14 084934" src="https://github.com/user-attachments/assets/e0123859-8a1e-448d-b5f0-dec11ff13634" />

A screen shot button is added, when click, it will generate a screenshot of the GUI.
